### PR TITLE
Fix `$locale_alternate` definition

### DIFF
--- a/layouts/partials/hugo-seo/private/params/og.html
+++ b/layouts/partials/hugo-seo/private/params/og.html
@@ -40,7 +40,7 @@
 
 
 {{ with .Translations }}
-  {{ $locale_alternate = slice }}
+  {{ $locale_alternate := slice }}
   {{ range . }}
     {{ $locale_alternate = $locale_alternate | append .Lang }}
   {{ end }}


### PR DESCRIPTION
## Summary

Without this change, build fails with multiple languages since `$locale_alternate` hasn't been defined.
