### PR TITLE
fix: omit breadcrumb for blank sections

### DIFF
--- a/.changeset/cuddly-socks-stare.md
+++ b/.changeset/cuddly-socks-stare.md
@@ -1,0 +1,5 @@
+---
+"@thulite/seo": patch
+---
+
+fix: omit breadcrumb for blank sections

--- a/layouts/_partials/seo/schemas/breadcrumb.html
+++ b/layouts/_partials/seo/schemas/breadcrumb.html
@@ -6,19 +6,21 @@
   {{- $scratchCtx := .scratch -}}
   {{- with .parent }}
     {{ partial "inline/breadcrumbData" (dict "scratch" $scratchCtx "parent" .Parent) }}
-    {{- $scratchCtx.Add "listItem" (slice (dict 
-      "@type" "ListItem"
-      "position" ($scratchCtx.Get "count")
-      "name" (.Title | humanize | title)
-      "item" .Permalink
-    )) -}}
-    {{- $scratchCtx.Add "count" 1 -}}
+    {{- if and .Permalink (ne .Permalink "") }}
+      {{- $scratchCtx.Add "listItem" (slice (dict
+        "@type" "ListItem"
+        "position" ($scratchCtx.Get "count")
+        "name" (.Title | humanize | title)
+        "item" .Permalink
+      )) -}}
+      {{- $scratchCtx.Add "count" 1 -}}
+    {{- end }}
   {{- end }}
 {{- end -}}
 
 {{ partial "inline/breadcrumbData" (dict "scratch" $scratch "parent" .Parent) }}
 
-{{- $scratch.Add "listItem" (slice (dict 
+{{- $scratch.Add "listItem" (slice (dict
   "@type" "ListItem"
   "position" ($scratch.Get "count")
   "name" (.Title | humanize | title)

--- a/layouts/_partials/seo/schemas/breadcrumb.html
+++ b/layouts/_partials/seo/schemas/breadcrumb.html
@@ -6,7 +6,7 @@
   {{- $scratchCtx := .scratch -}}
   {{- with .parent }}
     {{ partial "inline/breadcrumbData" (dict "scratch" $scratchCtx "parent" .Parent) }}
-    {{- if and .Permalink (ne .Permalink "") }}
+    {{- if .Permalink }}
       {{- $scratchCtx.Add "listItem" (slice (dict
         "@type" "ListItem"
         "position" ($scratchCtx.Get "count")


### PR DESCRIPTION
## Summary

When a section has no _index.md and/or a section is not rendered (e.g. footer section which is not displayed, just collects footer components) an incorrect breadcrumb schema is generated (empty string for item) Prevent that by omitting blank sections from the breadcrumb trail.

## Basic example

N/A

## Motivation

Google Search Console complains about the empty string breadcrumbs, so make Google happy.

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [x] Supports all screen sizes (if relevant) (not relevant)
- [x] Supports both light and dark mode (if relevant) (not relevant)
- [ ] Passes `npm run test` (if relevant)
