### PR TITLE
Enhance description handling

### DIFF
--- a/.changeset/serious-moose-confess.md
+++ b/.changeset/serious-moose-confess.md
@@ -1,0 +1,5 @@
+---
+"@thulite/seo": patch
+---
+
+Enhance description handling

--- a/layouts/_partials/seo/description.html
+++ b/layouts/_partials/seo/description.html
@@ -1,9 +1,51 @@
+{{- /* Error level when description not in recommended length: ignore, warning, or error. */}}
+{{- $errorLevel := or site.Params.seo.description.length.errorLevel "warning" | lower }}
+{{ $curPage := .Page }}
+
+{{- /* ignore description length for specified pages */ -}}
+{{- range site.Params.seo.description.lengthIgnores }}
+	{{- if gt (len (findRE . $curPage.TranslationKey)) 0 }}
+		{{ $errorLevel = "ignore" }}
+	{{- end }}
+{{- end }}
+
+{{- /* Do fallback to page summary before fallback to site description */ -}}
+{{- $summaryFallback := true -}}
+{{- if isset site.Params.seo.description "summaryFallback" }}
+	{{- $summaryFallback = site.Params.seo.description.summaryFallback }}
+{{- end }}
+
+{{- /* Validate error level. */}}
+{{- if not (in (slice "ignore" "warning" "error") $errorLevel) }}
+    {{- errorf "The seo descriptionLength is misconfigured. The errorLevel %q is invalid. Please check your site configuration." $errorLevel }}
+{{- end }}
+
 {{- $description := "" }}
 {{- if .Params.seo.description }}
 	{{- $description = .Params.seo.description }}
 {{- else if .Description }}
 	{{- $description = .Description }}
-{{- else }}
+{{- else if and $summaryFallback $curPage.Summary }}
+	{{- $description = $curPage.Summary | plainify }}
+{{- else if and $summaryFallback $curPage.Params.summary }}
+	{{- $description = $curPage.Params.summary | plainify }}
+{{- else if site.Params.seo.description.siteParamsFallback }}
   {{- $description = site.Params.Description }}
+{{- end }}
+{{- if ne $errorLevel "ignore" }}
+  {{- $lengthMessage := "" }}
+  {{- $descriptionLength := len $description }}
+	{{- if lt $descriptionLength 110 }}
+		{{- $lengthMessage = printf "Description too short on page '%s'. %d characters is < 110" .Page.TranslationKey $descriptionLength }}
+	{{- else if gt $descriptionLength 160 }}
+		{{- $lengthMessage = printf "Description too long on page '%s'. %d characters is >160" .Page.TranslationKey $descriptionLength }}
+	{{- end }}
+	{{- if ne $lengthMessage "" }}
+		{{ if eq $errorLevel "warning" }}
+			{{ warnf $lengthMessage }}
+		{{ else if $errorLevel "error" }}
+		  {{ errorf $lengthMessage }}
+		{{ end }}
+	{{- end }}
 {{- end }}
 <meta name="description" content="{{ $description }}">


### PR DESCRIPTION
## Summary

In short this improves technical SEO and gives more flexibility on generating the descriptions 
and summaries.

* Allow fallback to summary
* Allow preventing fallback to site description
* Allow to configure ignore, warning, or error on description too short or long.

## Basic example

### Sample config

`params.toml`

```toml
  [seo.description]
    summaryFallback = true # true (default) false
    lengthIgnores = [
      "^/404$",
      "^/footer.*",
      "^/tags.*",
      "^/doc$",
      "^/blog$",
      "^/contactsuccess$"
   ]
    siteParamsFallback = false
    [seo.description.length]
      errorlevel = 'warning' # warning (default) error ignore
```

## Motivation

1. I was tired of Webmaster Tools, Search Console, and Ahrefs complaining about my
   description lengths, so I made it fail the build until I fixed all the ones that I consider 
   relevant.
2. Falling back to the site description can be useful, but sometimes it just masks the lack of 
    reasonable description for the page.
3. Sometime you don't need both a summary and a description, even though they are used in two different ways.

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [x] Supports all screen sizes (if relevant) (not relevant - metadata)
- [x] Supports both light and dark mode (if relevant) (not relevant - metadata)
- [x] Passes `npm run test` (if relevant) (not relevant - Hugo config / content)
