### PR TITLE
description: fix lengthIgnores logic

### DIFF
--- a/.changeset/six-lizards-roll.md
+++ b/.changeset/six-lizards-roll.md
@@ -1,0 +1,5 @@
+---
+"@thulite/seo": patch
+---
+
+Fix broken description.lengthIgnores logic

--- a/layouts/_partials/seo/description.html
+++ b/layouts/_partials/seo/description.html
@@ -7,7 +7,7 @@
 
 {{- /* ignore description length for specified pages */ -}}
 {{- range site.Params.seo.description.lengthIgnores }}
-	{{- if gt (len (findRE . $curPage.TranslationKey)) 0 }}
+	{{- if eq . $curPage.TranslationKey }}
 		{{- $errorLevel = "ignore" }}
 	{{- end }}
 {{- end }}


### PR DESCRIPTION
Currently, the logic for `lengthIgnores` matches with a regular
expression. This starts to break in all sorts of hilarious ways when
trying to ignore `/`, or any parent.

Because every `.Page.TranslationKey` is prefixed with `/`, or `/parent`,
as they all stem from the root or the respective parent, the ignore
logic then matches *every page* (or every sub-page).

Certainly, this cannot be the intended behaviour; even still, it is
definitely not expected behaviour. Fix the logic by utilising a strict
comparison: `.Page.TranslationKey` must match **exactly** the given
`lengthIgnores.`

From my personal testing, this appears to fix the issue.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test` (if relevant)

P.S.: `npm run test` is not set up in this repository's `package.json` -- I'm sure you know about that already.
